### PR TITLE
feat(configs): :wrench: create typeORM configuration (and sqlite & postgreSQL, also)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ yarn.lock
 *.rest
 dist
 settings.json
+.env*
+*.sqlite

--- a/backend/ormconfig.js
+++ b/backend/ormconfig.js
@@ -1,0 +1,37 @@
+const dbConfig = {
+  synchronize: false
+}
+
+switch (process.env.NODE_ENV) {
+  case 'development':
+    Object.assign(dbConfig, {
+      type: 'sqlite',
+      database: 'db.sqlite',
+      entities: ['**/*.entity.js'],
+      synchronize: false
+    })
+    break
+  case 'test':
+    Object.assign(dbConfig, {
+      type: 'sqlite',
+      database: 'test.sqlite',
+      entities: ['**/*.entity.ts'],
+      synchronize: false
+    })
+  case 'production':
+    Object.assign(dbConfig, {
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      migrationsRun: true,
+      entities: ['dist/**/*.entity.js'],
+      ssl: {
+        rejectUnauthorized: false
+      }
+    })
+    break
+
+  default:
+    throw new Error('Unknown NODE_ENV: ' + process.env.NODE_ENV)
+}
+
+export default dbConfig

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,10 @@
   "main": "dist/src/main",
   "scripts": {
     "build": "nest build",
-    "start:dev": "nest start --watch",
-    "start:prod": "node ."
+    "start:dev": "cross-env NODE_ENV=development nest start --watch",
+    "start:debug": "cross-env NODE_ENV=development nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "typeorm": "cross-env NODE_ENV=development node --require ts-node/register ./node_modules/typeorm/cli.js"
   },
   "keywords": [],
   "author": "Gabriel Aguiar",
@@ -13,14 +15,22 @@
   "description": "",
   "dependencies": {
     "@nestjs/common": "^11.0.12",
+    "@nestjs/config": "^4.0.1",
     "@nestjs/core": "^11.0.12",
     "@nestjs/platform-express": "^11.0.12",
-    "reflect-metadata": "^0.2.2"
+    "@nestjs/typeorm": "^11.0.0",
+    "cross-env": "^7.0.3",
+    "mysql2": "^3.14.0",
+    "reflect-metadata": "^0.2.2",
+    "sqlite3": "^5.1.7",
+    "typeorm": "^0.3.21"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.5",
     "@nestjs/schematics": "^11.0.2",
     "@types/node": "^22.13.10",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.8.2"
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,15 @@
 import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import dbConfig from '@/ormconfig'
 
-@Module({})
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: `../.env.${process.env.NODE_ENV}`
+    }),
+    TypeOrmModule.forRoot(dbConfig)
+  ]
+})
 export class AppModule {}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -15,6 +15,7 @@
       "@/*": ["./*"]
     },
     "skipLibCheck": true,
-    "incremental": true
+    "incremental": true,
+    "allowJs": true
   }
 }


### PR DESCRIPTION
I didn't expect that the sqlite & postgreSQL configurations would be so simple to the point of coming as a consequence of the typeORM configuration.